### PR TITLE
Added missing reference

### DIFF
--- a/src/app/homepage/pages/techniques/configuration/configuration.component.ts
+++ b/src/app/homepage/pages/techniques/configuration/configuration.component.ts
@@ -91,6 +91,7 @@ export class AppService {
 
   get configServiceValidation() {
     return `
+import * as dotenv from 'dotenv';
 import * as Joi from 'joi';
 import * as fs from 'fs';
 


### PR DESCRIPTION
line 
import * as dotenv from 'dotenv';
is missing. dotenv is used within the constructor
